### PR TITLE
Hive subclass with dbQuoteString, odbcListColumns methods

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -61,3 +61,27 @@ setMethod("sqlCreateTable", "HDB",
     ))
   }
 )
+
+# Hive --------------------------------------------------------------------
+
+setClass("Hive", where = class_cache)
+
+#' @rdname hidden_aliases
+#' @export
+setMethod(
+  "dbQuoteString", "Hive",
+  function(conn, x, ...) {
+    if (is(x, "SQL"))
+        return(x)
+    if (!is.character(x))
+        stop("x must be character or SQL", call. = FALSE)
+    x <- gsub("'", "\\'", enc2utf8(x))
+    if (length(x) == 0L) {
+      DBI::SQL(character())
+    }
+    else {
+      str <- paste("'", x, "'", sep = "")
+      str[is.na(x)] <- "NULL"
+      DBI::SQL(str)
+    }
+  })


### PR DESCRIPTION
Hive uses C-style escape for string literals, so a single-quote inside a string literal should be replaced with `\'` and not `''` (as is currently the case). See #184 for details.